### PR TITLE
Fix OBIS theme loading in production mode

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -10,3 +10,7 @@ RUN echo ${TZ} > /etc/timezone
 RUN if ! [ /usr/share/zoneinfo/${TZ} -ef /etc/localtime ]; then \
         cp /usr/share/zoneinfo/${TZ} /etc/localtime ;\
     fi ;
+
+# Install OBIS theme extension
+COPY src/ckanext-obis_theme ${APP_DIR}/src/ckanext-obis_theme
+RUN pip install -e ${APP_DIR}/src/ckanext-obis_theme

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
   ckan:
     container_name: ${CKAN_CONTAINER_NAME}
     build:
-      context: ckan/
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: ckan/Dockerfile
       args:
         - TZ=${TZ}
     env_file:


### PR DESCRIPTION
- Change build context from `ckan/` to `.` in `docker-compose.yml`
- Add OBIS theme installation steps to `ckan/Dockerfile`
- Enables obis_theme plugin to work in production mode
- Development mode continues to work unchanged